### PR TITLE
feat: Add functionality to clone organization repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 
-# GitHub Starred Repository Cloner
+# GitHub Repository Cloner
 
-This Python script automates the process of cloning all repositories starred by a GitHub user. Simply provide your GitHub username and Personal Access Token (PAT), and it will fetch and clone the repositories into a local directory.
+This Python script automates the process of cloning repositories from GitHub. It can clone all repositories starred by a user or all repositories from all members of a GitHub organization.
 
 ## Features
-- Automatically fetches starred repositories.
-- Clones each repository locally.
+- Clone all starred repositories for a user.
+- Clone all public repositories from all members of an organization.
+- Interactive CLI for selecting the cloning action.
+- Handles GitHub API rate limits to avoid being blocked.
+- Fetches all pages of repositories using pagination.
 - Skips already cloned repositories to avoid duplication.
 
 ## Requirements
 - Python 3.x
 - `requests` library (`pip install requests`)
 - `GitPython` library (`pip install gitpython`)
-- A GitHub Personal Access Token (PAT)
+- A GitHub Personal Access Token (PAT) with `repo` and `read:org` scopes.
 
 ## Installation & Usage
 
@@ -24,24 +27,26 @@ cd clone-github-starred
 
 ### 2. Install Dependencies
 ```bash
-pip install -r requirements.txt
+pip install requests gitpython
 ```
 
-### 3. Configure Your Credentials
-Edit `github-clone.py` and set your GitHub username and PAT:
-```python
-username = 'Enter Your Username'
-token = 'Enter Your PAT'
-```
+### 3. Run the Script
+Execute the script with the required arguments.
 
-### 4. Run the Script
-Execute the script to clone starred repositories:
+**To clone your starred repositories:**
 ```bash
-python github-clone.py
+python github-clone.py <your-username> <your-token> --starred
 ```
+
+**To clone repositories from an organization:**
+```bash
+python github-clone.py <your-username> <your-token> --org <organization-name>
+```
+
+Replace `<your-username>`, `<your-token>`, and `<organization-name>` with your actual GitHub username, Personal Access Token, and the name of the organization.
 
 ## Troubleshooting
-- Ensure your PAT has the necessary permissions to read repository data.
+- Ensure your PAT has the necessary permissions (`repo` and `read:org`).
 - Verify your network connection if cloning fails.
 - If repositories already exist, the script will skip them.
 
@@ -50,6 +55,5 @@ Feel free to submit issues or pull requests to enhance the functionality.
 
 ## License
 This project is licensed under the MIT License.
-
 ```
 ```

--- a/github-clone.py
+++ b/github-clone.py
@@ -1,41 +1,107 @@
 import requests
 import git
 import os
+import argparse
+import time
 
-# Your GitHub username
-username = 'Enter Your Username'
-# Example username = 'manupawickramasinghe'
+def get_paginated_data(url, headers):
+    """
+    Fetches all pages of data from a paginated API endpoint.
+    """
+    results = []
+    while url:
+        response = requests.get(url, headers=headers)
 
-# Your GitHub personal access token
-token = 'enter your PAT'
+        # Check rate limit
+        if response.status_code == 403 and 'rate limit exceeded' in response.text.lower():
+            rate_limit_reset = int(response.headers.get('X-RateLimit-Reset', 0))
+            sleep_time = max(rate_limit_reset - time.time(), 0) + 10 # wait 10 seconds buffer
+            print(f"Rate limit exceeded. Waiting for {sleep_time:.0f} seconds...")
+            time.sleep(sleep_time)
+            continue
 
-# Example token = '123123123133'
+        response.raise_for_status()
+        results.extend(response.json())
 
-# GitHub API URL for starred repos
-url = f'https://api.github.com/users/{username}/starred'
+        if 'next' in response.links:
+            url = response.links['next']['url']
+        else:
+            url = None
 
-# Directory to clone repos into
-clone_dir = 'starred_repos'
+    return results
 
-# Create the directory if it doesn't exist
-if not os.path.exists(clone_dir):
-    os.makedirs(clone_dir)
-
-# Fetch starred repos
-response = requests.get(url, auth=(username, token))
-repos = response.json()
-
-# Clone each repo
-for repo in repos:
-    repo_name = repo['name']
-    repo_url = repo['clone_url']
-    repo_dir = os.path.join(clone_dir, repo_name)
-    
+def clone_repo(repo_url, repo_dir):
+    """
+    Clones a repository from a given URL into a specified directory.
+    """
     if not os.path.exists(repo_dir):
-        print(f'Cloning {repo_name}...')
+        print(f"Cloning {repo_dir}...")
         git.Repo.clone_from(repo_url, repo_dir)
-        print(f'Finished cloning {repo_name}')
+        print(f"Finished cloning {repo_dir}")
     else:
-        print(f'{repo_name} already exists, skipping...')
+        print(f"{repo_dir} already exists, skipping...")
 
-print('All repositories have been cloned.')
+def get_starred_repos(username, token):
+    """
+    Fetches all starred repositories for a given user.
+    """
+    url = f"https://api.github.com/users/{username}/starred"
+    headers = {'Authorization': f'token {token}'}
+    return get_paginated_data(url, headers)
+
+def get_org_members(org_name, token):
+    """
+    Fetches all members of a given organization.
+    """
+    url = f"https://api.github.com/orgs/{org_name}/members"
+    headers = {'Authorization': f'token {token}'}
+    members = get_paginated_data(url, headers)
+    return [member['login'] for member in members]
+
+def get_user_repos(username, token):
+    """
+    Fetches all public repositories for a given user.
+    """
+    url = f"https://api.github.com/users/{username}/repos"
+    headers = {'Authorization': f'token {token}'}
+    return get_paginated_data(url, headers)
+
+def main():
+    parser = argparse.ArgumentParser(description="Clone GitHub repositories.")
+    parser.add_argument("username", help="Your GitHub username")
+    parser.add_argument("token", help="Your GitHub Personal Access Token")
+    
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--starred", action="store_true", help="Clone your starred repositories.")
+    group.add_argument("--org", help="Clone repositories from all members of an organization.")
+
+    args = parser.parse_args()
+
+    if args.starred:
+        print("Fetching your starred repositories...")
+        repos = get_starred_repos(args.username, args.token)
+        clone_dir = 'starred_repos'
+    elif args.org:
+        print(f"Fetching members of organization '{args.org}'...")
+        members = get_org_members(args.org, args.token)
+        print(f"Found {len(members)} members.")
+
+        repos = []
+        for member in members:
+            print(f"Fetching repositories for member '{member}'...")
+            repos.extend(get_user_repos(member, args.token))
+        clone_dir = f'{args.org}_repos'
+
+    if not os.path.exists(clone_dir):
+        os.makedirs(clone_dir)
+
+    for repo in repos:
+        repo_name = repo['name']
+        repo_url = repo['clone_url']
+        repo_dir = os.path.join(clone_dir, repo_name)
+        clone_repo(repo_url, repo_dir)
+
+    print("All repositories have been cloned.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit enhances the GitHub cloning script with the following features:

- **Clone Organization Repositories:** Adds the capability to clone all public repositories from every member of a specified GitHub organization.
- **Command-Line Interface (CLI):** Introduces a CLI using `argparse` to allow users to choose between cloning their starred repositories or repositories from an organization.
- **Rate Limiting and Pagination:** Implements robust handling for GitHub API rate limits and pagination to ensure the script can handle a large number of repositories without failing.
- **Refactored Code:** The script has been refactored into modular functions for better readability and maintainability.
- **Updated Documentation:** The README.md file has been updated to reflect the new features and provide clear usage instructions.